### PR TITLE
Remove token from localstorage on 401 response

### DIFF
--- a/src/react-admin/authProvider.js
+++ b/src/react-admin/authProvider.js
@@ -5,7 +5,7 @@ import { USER_INFO } from '../constants';
 export default {
   login: async (googleUser) => {
     const { id_token: token } = googleUser.getAuthResponse();
-    await request('/auth/login', {
+    await request('auth/login', {
       method: 'POST',
       body: JSON.stringify({
         token,

--- a/src/react-admin/httpClient.js
+++ b/src/react-admin/httpClient.js
@@ -32,6 +32,10 @@ export default async (url, options) => {
 
     return response;
   } catch (error) {
-    console.error(error);
+    if (error.status === 401) {
+      localStorage.removeItem(USER_INFO);
+    } else {
+      console.error(error);
+    }
   }
 };


### PR DESCRIPTION
Removes the token when backend responds with a status 401. This makes the admin redirect the user back to the login screen.