### PR TITLE
Disable delete published communications

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/src/components/Communication/BulkActionButtons.js
+++ b/src/components/Communication/BulkActionButtons.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { BulkDeleteButton, useListContext } from "react-admin";
+import Tooltip from "@material-ui/core/Tooltip";
+
+import { IS_PUBLISHED } from "./consts";
+
+const CommunicationsBulkActionButtons = () => {
+  const { data, selectedIds } = useListContext();
+  const selectedIdsContainPublishedComm = selectedIds.some(
+    (id) => data[id][IS_PUBLISHED]
+  );
+
+  return selectedIdsContainPublishedComm ? (
+    <Tooltip title="Alguno de los comunicados seleccionados ya fue publicado">
+      <div>
+        <BulkDeleteButton disabled />
+      </div>
+    </Tooltip>
+  ) : (
+    <BulkDeleteButton />
+  );
+};
+
+export default CommunicationsBulkActionButtons;

--- a/src/components/Communication/CommunicationList.js
+++ b/src/components/Communication/CommunicationList.js
@@ -17,8 +17,10 @@ import {
 } from './consts';
 import EditButton from './EditButton';
 
+import BulkActionButtons from './BulkActionButtons';
+
 export const CommunicationList = (props) => (
-  <List {...props}>
+  <List bulkActionButtons={<BulkActionButtons />} {...props}>
     <Datagrid>
       <TextField source={ID} />
       <TextField source={TITLE} />


### PR DESCRIPTION
Deshabilita el botón de borrar elementos cuando alguno de los comunicados seleccionados esta publicado.
![Oct-18-2020 20-48-14](https://user-images.githubusercontent.com/39418440/96389089-b9c4c300-1183-11eb-97a9-0d7a1ff7ae10.gif)
