### PR TITLE
fix: Correción de feedbacks del Sprint 3

### DIFF
--- a/src/components/Communication/BulkActionButtons.js
+++ b/src/components/Communication/BulkActionButtons.js
@@ -17,7 +17,7 @@ const CommunicationsBulkActionButtons = (props) => {
       </div>
     </Tooltip>
   ) : (
-    <BulkDeleteButton {...props} />
+    <BulkDeleteButton undoable={false} {...props} />
   );
 };
 

--- a/src/components/Communication/CommunicationEdit.js
+++ b/src/components/Communication/CommunicationEdit.js
@@ -11,10 +11,11 @@ import {
 import { formImageDataToBase64 } from '../../utils';
 import { ID, TITLE, TEXT, IS_PUBLISHED, IMAGE } from './consts';
 import MyImageField from './MyImageField';
+import ConfirmDeleteToolbar from '../common/ConfirmDeleteToolbar';
 
 export const CommunicationEdit = (props) => (
   <Edit undoable={false} transform={formImageDataToBase64} {...props}>
-    <SimpleForm>
+    <SimpleForm toolbar={<ConfirmDeleteToolbar />}>
       <TextInput disable source={ID} />
       <TextInput source={TITLE} validate={[required()]} />
       <TextInput multiline source={TEXT} validate={[required()]} />

--- a/src/components/Communication/CommunicationList.js
+++ b/src/components/Communication/CommunicationList.js
@@ -22,12 +22,26 @@ import BulkActionButtons from './BulkActionButtons';
 import CommunicationFilter from './CommunicationFilter';
 
 export const CommunicationList = (props) => (
-  <List bulkActionButtons={<BulkActionButtons />} filters={<CommunicationFilter />} {...props}>
+  <List
+    bulkActionButtons={<BulkActionButtons />}
+    filters={<CommunicationFilter />}
+    {...props}
+  >
     <Datagrid>
       <TextField source={ID} />
       <TextField source={TITLE} />
       <BooleanField source={IS_PUBLISHED} />
-      <DateField source={DATE_TIME} />
+      <DateField
+        source={DATE_TIME}
+        options={{
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+        }}
+        showTime
+      />
       <DateField source={CREATED_AT} />
       <DateField source={UPDATED_AT} />
       <EditButton />

--- a/src/components/Review/ActionItemListInput.js
+++ b/src/components/Review/ActionItemListInput.js
@@ -4,6 +4,7 @@ import { useFormState, useForm } from 'react-final-form';
 
 import ActionItemIterator from './ActionItemIterator';
 import { DESCRIPTION, COMPLETED } from './consts';
+import ConditionalInput from '../common/ConditionalInput';
 
 const ActionItemListInput = ({ source, label, disableCompleted, isEdit }) => {
   const { values } = useFormState();
@@ -28,7 +29,9 @@ const ActionItemListInput = ({ source, label, disableCompleted, isEdit }) => {
           label="description"
           validate={[required()]}
         />
-        <BooleanInput
+        <ConditionalInput
+          inputComponent={<BooleanInput />}
+          conditionValue={isEdit}
           disabled={disableCompleted}
           source={COMPLETED}
           label="completed"

--- a/src/components/Review/ReviewCreate.js
+++ b/src/components/Review/ReviewCreate.js
@@ -41,11 +41,12 @@ export const ReviewCreate = (props) => {
           label="usuario"
           reference="users"
           validate={[required()]}
+          filter={{ is_active: true }}
         >
           <SelectInput optionText={USER_NAME} />
         </ReferenceInput>
-        <TextInput source={TITLE} />
-        <TextInput multiline source={TEXT} />
+        <TextInput source={TITLE} validate={[required()]} />
+        <TextInput multiline source={TEXT} fullWidth />
         <ActionItemListInput
           source={USER_ACTION_LIST}
           disableCompleted

--- a/src/components/Review/ReviewEdit.js
+++ b/src/components/Review/ReviewEdit.js
@@ -18,17 +18,18 @@ import {
   USER_NAME,
 } from './consts';
 import transformActionList from './transformActionList';
+import ConfirmDeleteToolbar from '../common/ConfirmDeleteToolbar';
 
 export const ReviewEdit = (props) => (
   <Edit transform={transformActionList} {...props}>
-    <SimpleForm>
+    <SimpleForm toolbar={<ConfirmDeleteToolbar />}>
       <ReferenceInput
         disable
         source={USER_ID}
         label="usuario"
         reference="users"
       >
-        <SelectInput optionText={USER_NAME} />
+        <SelectInput disable optionText={USER_NAME} />
       </ReferenceInput>
       <ReferenceInput
         disable
@@ -36,10 +37,10 @@ export const ReviewEdit = (props) => (
         label="reviewer"
         reference="users"
       >
-        <SelectInput optionText={USER_NAME} />
+        <SelectInput disable optionText={USER_NAME} />
       </ReferenceInput>
-      <TextInput source={TITLE} />
-      <TextInput multiline source={TEXT} />
+      <TextInput disable source={TITLE} />
+      <TextInput multiline source={TEXT} fullWidth />
       <ActionItemListInput
         isEdit
         source={USER_ACTION_LIST}

--- a/src/components/Review/ReviewList.js
+++ b/src/components/Review/ReviewList.js
@@ -6,13 +6,18 @@ import {
   TextField,
   DateField,
   EditButton,
+  BulkDeleteButton,
 } from 'react-admin';
 import { TITLE, USER_ID, USER_NAME, CREATED_AT } from './consts';
 
 import ReviewFilter from './ReviewFilter';
 
 export const ReviewList = (props) => (
-  <List filters={<ReviewFilter />} {...props}>
+  <List
+    filters={<ReviewFilter />}
+    bulkActionButtons={<BulkDeleteButton undoable={false} />}
+    {...props}
+  >
     <Datagrid>
       <ReferenceField source={USER_ID} label="User" reference="users">
         <TextField source={USER_NAME} />

--- a/src/components/Review/transformActionList.js
+++ b/src/components/Review/transformActionList.js
@@ -3,7 +3,25 @@ import {
   REVIEWER_ACTION_LIST,
   USER_ACTION_LIST_ATT,
   REVIEWER_ACTION_LIST_ATT,
+  COMPLETED,
 } from './consts';
+
+const renameAndDelete = (form, old_name, new_name) => {
+  form[new_name] = form[old_name];
+  delete form[old_name];
+};
+
+const addDefaultCompleted = (form, attribute) => {
+  if (!form[attribute]) return;
+  form[attribute].forEach((actionItem) => {
+    if (
+      !actionItem.hasOwnProperty(COMPLETED) &&
+      !actionItem.hasOwnProperty('_destroy')
+    ) {
+      actionItem[COMPLETED] = false;
+    }
+  });
+};
 
 const transformActionList = (formData) => {
   // eslint-disable-next-line no-unused-expressions
@@ -18,10 +36,11 @@ const transformActionList = (formData) => {
   });
   delete formData[`${REVIEWER_ACTION_LIST}_toDestroy`];
 
-  formData[USER_ACTION_LIST_ATT] = formData[USER_ACTION_LIST];
-  formData[REVIEWER_ACTION_LIST_ATT] = formData[REVIEWER_ACTION_LIST];
-  delete formData[USER_ACTION_LIST];
-  delete formData[REVIEWER_ACTION_LIST];
+  renameAndDelete(formData, USER_ACTION_LIST, USER_ACTION_LIST_ATT);
+  renameAndDelete(formData, REVIEWER_ACTION_LIST, REVIEWER_ACTION_LIST_ATT);
+
+  addDefaultCompleted(formData, USER_ACTION_LIST_ATT);
+  addDefaultCompleted(formData, REVIEWER_ACTION_LIST_ATT);
   return formData;
 };
 

--- a/src/components/common/ConditionalInput.js
+++ b/src/components/common/ConditionalInput.js
@@ -2,15 +2,20 @@ import { cloneElement, useEffect } from 'react';
 import { useInput } from 'react-admin';
 import { useFormState } from 'react-final-form';
 
-const ConditionalInput = ({ inputComponent, conditionField, ...props }) => {
+const ConditionalInput = ({
+  inputComponent,
+  conditionField,
+  conditionValue,
+  ...props
+}) => {
   const {
     input: { onChange },
   } = useInput(props);
   const { values } = useFormState();
   useEffect(() => {
-    !values[conditionField] && onChange();
-  }, [conditionField, onChange, props.source, values]);
-  return values[conditionField]
+    !values[conditionField] && !conditionValue && onChange();
+  }, [conditionField, conditionValue, onChange, props.source, values]);
+  return values[conditionField] || conditionValue
     ? cloneElement(inputComponent, { ...props })
     : null;
 };

--- a/src/components/common/ConfirmDeleteToolbar.js
+++ b/src/components/common/ConfirmDeleteToolbar.js
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { SaveButton, DeleteButton, Toolbar } from 'react-admin';
+import { withStyles } from '@material-ui/core';
+
+const toolbarStyles = {
+  toolbar: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+};
+
+const ConfirmDeleteToolbar = withStyles(toolbarStyles)((props) => (
+  <Toolbar {...props}>
+    <SaveButton />
+    <DeleteButton undoable={false} />
+  </Toolbar>
+));
+
+export default ConfirmDeleteToolbar;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -9,9 +9,21 @@ const convertFileToBase64 = (file) =>
     reader.readAsDataURL(file.rawFile);
   });
 
-export const formImageDataToBase64 = async (formData) => ({
-  ...formData,
-  [IMAGE]: (formData[IMAGE] && typeof formData[IMAGE] !== 'string')
-    ? { "data": await convertFileToBase64(formData[IMAGE]) }
-    : undefined,
-});
+export const formImageDataToBase64 = async (formData) => {
+  if (!formData.hasOwnProperty(IMAGE)) {
+    return formData;
+  }
+  let new_image;
+  if (formData[IMAGE] === null) {
+    new_image = { _destroy: true };
+  } else {
+    new_image =
+      typeof formData[IMAGE] !== 'string'
+        ? { data: await convertFileToBase64(formData[IMAGE]) }
+        : undefined;
+  }
+  return {
+    ...formData,
+    [IMAGE]: new_image,
+  };
+};


### PR DESCRIPTION
Se corrigen los siguientes feedbacks del Sprint 3:
- [Una vez que un communicado tiene imagen, no es posible removerla](https://trello.com/c/gvqC1myVhttps://trello.com/c/gvqC1myV)
- [Dashboard : No deberían poderse elegir usuarios que no estan activos para crear una review](https://trello.com/c/HTdygo8x)
- [Seria bueno que el dashboard muestre la hora de recurrencia de un comunicado recurrente](https://trello.com/c/ML4J9aLV)
- [Dashboard : El titulo de una 1o1 no deberia poder editarse](https://trello.com/c/GfnNoV68)
- [Quitar el botón de completed en el crear de las 1o1](https://trello.com/c/R7JZkhj4)
- [Hacer el área de comentarios de una 1o1 más ancho](https://trello.com/c/Zv5igfkL)
- [Agregar una confirmación antes de cada acción de borrar en el Admin](https://trello.com/c/pjmVAGWj)